### PR TITLE
Fixed OK Signal on MQTT Reconnect

### DIFF
--- a/ESP/.luacheckrc
+++ b/ESP/.luacheckrc
@@ -37,6 +37,7 @@ stds.lasertag = {
 		"fireWeapon",
 
 		"gameRunning",
+		"systemIsSetUp",
 
 		"subscribeTo",
 		"registerUARTCommand",

--- a/ESP/Lasertag.lua
+++ b/ESP/Lasertag.lua
@@ -66,6 +66,7 @@ subscribeTo(playerTopic .. "/ID", 1,
 
 tmr.create():alarm(3000, tmr.ALARM_SINGLE, function()
 	homeQTT:publish(playerTopic .. "/Connection", "OK", 1, 1);
+	systemIsSetUp = true;
 end);
 
 setVestColor(1);

--- a/ESP/MQTTConnect.lua
+++ b/ESP/MQTTConnect.lua
@@ -50,7 +50,7 @@ function resubToAll()
 	end
 end
 
-mqttSubTimer:register(2000, tmr.ALARM_SEMI, mqtt_raw_slow_subscribe);
+mqttSubTimer:register(1000, tmr.ALARM_SEMI, mqtt_raw_slow_subscribe);
 
 ---------------
 --- RECONNECTING FUNCTIONS
@@ -82,6 +82,12 @@ function mqtt_Connect()
 				homeQTT_FirstConnect();
 				homeQTT_FirstConnect = nil;
 			end
+
+			tmr.create():alarm(1000, tmr.ALARM_SINGLE, function()
+				if(systemIsSetUp) then
+					homeQTT:publish(playerTopic .. "/Connection", "OK", 1, 1);
+				end
+			end);
 		end,
 		function(client, reason)
 			homeQTT_connected = false;

--- a/ESP/init.lua
+++ b/ESP/init.lua
@@ -6,6 +6,8 @@ dofile("MQTTConnect.lua");
 
 StartSymbol = string.byte("!");
 
+systemIsSetUp = false;
+
 tmr.create():alarm(2000, tmr.ALARM_SINGLE,
 	function(t)
 


### PR DESCRIPTION
Before, we forgot to re-send the "OK" signal if the lasertag sets had had a disconnect and had reconnected.
With this, the system *should* automatically add an "OK" signal on MQTT reconnect, if the initial "OK" had already been sent (which is the use of the `systemIsSetUp` variable.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xasworks/lzrtag/21)
<!-- Reviewable:end -->
