### PR TITLE
"SAFEMODE" start after crashing during file-loading

### DIFF
--- a/ESP/.luacheckrc
+++ b/ESP/.luacheckrc
@@ -44,6 +44,8 @@ stds.lasertag = {
 		"fireWeapon",
 
 		"gameRunning",
+
+		"SAFEMODE",
 	}
 }
 

--- a/ESP/ConsoleRedir.lua
+++ b/ESP/ConsoleRedir.lua
@@ -35,9 +35,7 @@ subscribeTo(playerTopic .. "/Console/FileWrite", 2,
 				file.remove(targetFilename);
 				file.rename(targetFilename .. ".BKUP", targetFilename);
 
-				if(SAFEMODE) then
-					file.remove("BOOT_SAFECHECK");
-				end
+				file.remove("BOOT_SAFECHECK");
 			end
 
 			homeQTT:publish(playerTopic .. "/Console/FileAnswer",

--- a/ESP/ConsoleRedir.lua
+++ b/ESP/ConsoleRedir.lua
@@ -34,6 +34,10 @@ subscribeTo(playerTopic .. "/Console/FileWrite", 2,
 
 				file.remove(targetFilename);
 				file.rename(targetFilename .. ".BKUP", targetFilename);
+
+				if(SAFEMODE) then
+					file.remove("BOOT_SAFECHECK");
+				end
 			end
 
 			homeQTT:publish(playerTopic .. "/Console/FileAnswer",

--- a/ESP/MQTTConnect.lua
+++ b/ESP/MQTTConnect.lua
@@ -107,6 +107,7 @@ end
 wifi.eventmon.register(wifi.eventmon.STA_GOT_IP,
 	function(t)
 		mqtt_Connect();
+		sntp.sync(nil, nil, nil, 1);
 	end
 );
 if(wifi.sta.getip()) then

--- a/ESP/init.lua
+++ b/ESP/init.lua
@@ -6,6 +6,8 @@ dofile("MQTTConnect.lua");
 
 StartSymbol = string.byte("!");
 
+SAFEMODE = not file.exists("BOOT_SAFECHECK");
+
 tmr.create():alarm(2000, tmr.ALARM_SINGLE,
 	function(t)
 
@@ -36,8 +38,18 @@ tmr.create():alarm(2000, tmr.ALARM_SINGLE,
 					onMQTTConnect(
 						function()
 							dofile("ConsoleRedir.lua");
-							dofile("Lasertag.lua");
-							dofile("MQTTPing.lua");
+
+							if(not SAFEMODE) then
+								file.open("BOOT_SAFECHECK","w"):close();
+
+								dofile("Lasertag.lua");
+								dofile("MQTTPing.lua");
+
+								tmr.create():alarm(3000, tmr.ALARM_SINGLE,
+									function()
+										file.remove("BOOT_SAFECHECK");
+									end);
+							end
 						end
 					);
 				end

--- a/ESP/init.lua
+++ b/ESP/init.lua
@@ -30,7 +30,7 @@ tmr.create():alarm(2000, tmr.ALARM_SINGLE,
 				if(data == StartSymbol) then
 					noTagTimer:unregister();
 
-					uart.write( 0, 10, 10,		-- Vibrate a little?
+					uart.write( 0, 10, 10,		-- Vibrate a little
 									11, 10, 7, 7,	-- Connect buzz
 									101, 2);			-- Set blue team
 
@@ -51,9 +51,10 @@ tmr.create():alarm(2000, tmr.ALARM_SINGLE,
 										file.remove("BOOT_SAFECHECK");
 									end);
 							else
-								uart.write(	200, 5,	-- Bright blink mode
-												101, 0,	-- Red team
-												11, 100, 33, 34); -- 2kHz "error" buzz
+								uart.write(	0, 200, 10,	-- Bright blink mode
+												101, 0,		-- Red team
+												11, 100, 32, 34); -- 2kHz "error" buzz
+								homeQTT:publish(playerTopic .. "/Connection", "SAFEMODE", 0, 1);
 							end
 						end
 					);

--- a/ESP/init.lua
+++ b/ESP/init.lua
@@ -30,9 +30,9 @@ tmr.create():alarm(2000, tmr.ALARM_SINGLE,
 				if(data == StartSymbol) then
 					noTagTimer:unregister();
 
-					uart.write( 0, 10, 10,
-									11, 10, 7, 7,
-									101, 2);
+					uart.write( 0, 10, 10,		-- Vibrate a little?
+									11, 10, 7, 7,	-- Connect buzz
+									101, 2);			-- Set blue team
 
 					uart.on("data", 0, function(d) end, 0);
 
@@ -50,6 +50,10 @@ tmr.create():alarm(2000, tmr.ALARM_SINGLE,
 									function()
 										file.remove("BOOT_SAFECHECK");
 									end);
+							else
+								uart.write(	200, 5,	-- Bright blink mode
+												101, 0,	-- Red team
+												11, 100, 33, 34); -- 2kHz "error" buzz
 							end
 						end
 					);

--- a/ESP/init.lua
+++ b/ESP/init.lua
@@ -6,7 +6,7 @@ dofile("MQTTConnect.lua");
 
 StartSymbol = string.byte("!");
 
-SAFEMODE = not file.exists("BOOT_SAFECHECK");
+SAFEMODE = file.exists("BOOT_SAFECHECK");
 systemIsSetUp = false;
 
 tmr.create():alarm(2000, tmr.ALARM_SINGLE,
@@ -40,13 +40,13 @@ tmr.create():alarm(2000, tmr.ALARM_SINGLE,
 						function()
 							dofile("ConsoleRedir.lua");
 
-							if(not SAFEMODE) then
+							if(not(SAFEMODE)) then
 								file.open("BOOT_SAFECHECK","w"):close();
 
 								dofile("Lasertag.lua");
 								dofile("MQTTPing.lua");
 
-								tmr.create():alarm(3000, tmr.ALARM_SINGLE,
+								tmr.create():alarm(1500, tmr.ALARM_SINGLE,
 									function()
 										file.remove("BOOT_SAFECHECK");
 									end);

--- a/ESP/init.lua
+++ b/ESP/init.lua
@@ -38,8 +38,6 @@ tmr.create():alarm(2000, tmr.ALARM_SINGLE,
 							dofile("ConsoleRedir.lua");
 							dofile("Lasertag.lua");
 							dofile("MQTTPing.lua");
-
-							sntp.sync(nil, nil, nil, 1);
 						end
 					);
 				end

--- a/Ruby/GameInterface/DataTransfer.rb
+++ b/Ruby/GameInterface/DataTransfer.rb
@@ -14,11 +14,11 @@ module Lasertag
 		attr_reader :BlockNum
 		attr_reader :currentBlock
 
-		def initialize(targetPlayer, filepath, **options)
+		def initialize(mqtt, target, filepath, **options)
 			@state = :IDLE;
 
-			@mqtt 	= targetPlayer.mqtt;
-			@Target = targetPlayer.name;
+			@mqtt 	= mqtt;
+			@Target = target;
 			@TransferTopic = "Lasertag/Players/#{@Target}/"
 
 			@retryAttempts  = 0;


### PR DESCRIPTION
This new system should provide a "net" to catch fatal errors transferred via the file transfer system.
Instead of continuously running files, the system detects that it has crashed within the first three seconds of loading lasertag files, which leaves the file "BOOT_SAFECHECK" written to flash.

Upon the next boot of the weapon, this file is detected, and the system does /not/ load lasertag files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xasworks/lzrtag/22)
<!-- Reviewable:end -->
