### PR TITLE
Improved ESP to AVR coms

### DIFF
--- a/ESP/Commands.md
+++ b/ESP/Commands.md
@@ -5,7 +5,7 @@ Number | Short Desc. | Data
 A000 | Shot cfg | 0 = Disable, 1 = Enable, 99 = Immediate, >=100 Set consequent shots
 E000 | Trigger status changed
 E001 | Shot detected | Player, ShotID
-A010 | Vibrate 	| Time (10ms)
+A010 | Vibrate 	| Time (in MS, up to 2^16 ms)
 A011 | Buzzer 	| Time (10ms), Start, End (60Hz)
 A012 | Vest Blink Override | Level + time in segments
 

--- a/ESP/Commands.md
+++ b/ESP/Commands.md
@@ -6,7 +6,7 @@ A000 | Shot cfg | 0 = Disable, 1 = Enable, 99 = Immediate, >=100 Set consequent 
 E000 | Trigger status changed
 E001 | Shot detected | Player, ShotID
 A010 | Vibrate 	| Time (in MS, up to 2^16 ms)
-A011 | Buzzer 	| Time (10ms), Start, End (60Hz)
+A011 | Buzzer 	| Time (in ms), Start, End (in Hz)
 A012 | Vest Blink Override | Level + time in segments
 
 ### Config commands

--- a/ESP/Commands.md
+++ b/ESP/Commands.md
@@ -7,7 +7,7 @@ E000 | Trigger status changed
 E001 | Shot detected | Player, ShotID
 A010 | Vibrate 	| Time (10ms)
 A011 | Buzzer 	| Time (10ms), Start, End (60Hz)
-A012 | Vest Blink Override | Level + time in 100ms
+A012 | Vest Blink Override | Level + time in segments
 
 ### Config commands
 Number | Short Desc.

--- a/ESP/Lasertag.lua
+++ b/ESP/Lasertag.lua
@@ -18,7 +18,7 @@ function ping(sFreq, eFreq, duration)
 end
 
 function vibrate(duration)
-	uart.write(0, 10, duration/10);
+	uart.write(0, 10, duration%255, duration/255);
 end
 
 function fireWeapon()

--- a/ESP/Lasertag.lua
+++ b/ESP/Lasertag.lua
@@ -14,7 +14,10 @@ function overrideVest(duration, brightness)
 end
 
 function ping(sFreq, eFreq, duration)
-	uart.write(0, 11, duration/10 or 2, sFreq/60 or 67, eFreq/60 or sFreq/60 or 67);
+	duration = duration or 20;
+	sFreq = sFreq or 4000;
+	eFreq = eFreq or sFreq;
+	uart.write(0, 11, duration%255, duration/255, sFreq%255, sFreq/255, eFreq%255, eFreq/255);
 end
 
 function vibrate(duration)

--- a/ESP/init.lua
+++ b/ESP/init.lua
@@ -30,9 +30,9 @@ tmr.create():alarm(2000, tmr.ALARM_SINGLE,
 				if(data == StartSymbol) then
 					noTagTimer:unregister();
 
-					uart.write( 0, 10, 10,		-- Vibrate a little
-									11, 10, 7, 7,	-- Connect buzz
-									101, 4);			-- Set blue team
+					uart.write( 0, 10, 100, 0,					-- Vibrate a little
+									11, 100, 0, 164, 1, 164, 1,-- Connect buzz
+									101, 4);							-- Set blue team
 
 					uart.on("data", 0, function(d) end, 0);
 
@@ -64,6 +64,7 @@ tmr.create():alarm(2000, tmr.ALARM_SINGLE,
 			end
 		, 0);
 
-		uart.write(0, StartSymbol);
+		-- Flush any potential buffer, then send the start signal
+		uart.write(0, 255, 255, 255, 255, 255, 255, StartSymbol);
 	end
 );

--- a/EclipseWS/MainBoard/.cproject
+++ b/EclipseWS/MainBoard/.cproject
@@ -112,7 +112,7 @@
 							</tool>
 							<tool id="de.innot.avreclipse.tool.cppcompiler.app.release.396738423" name="AVR C++ Compiler" superClass="de.innot.avreclipse.tool.cppcompiler.app.release">
 								<option id="de.innot.avreclipse.cppcompiler.option.debug.level.107397421" name="Generate Debugging Info" superClass="de.innot.avreclipse.cppcompiler.option.debug.level" value="de.innot.avreclipse.cppcompiler.option.debug.level.none" valueType="enumerated"/>
-								<option id="de.innot.avreclipse.cppcompiler.option.optimize.299436097" name="Optimization Level" superClass="de.innot.avreclipse.cppcompiler.option.optimize" value="de.innot.avreclipse.cppcompiler.optimize.size" valueType="enumerated"/>
+								<option id="de.innot.avreclipse.cppcompiler.option.optimize.299436097" name="Optimization Level" superClass="de.innot.avreclipse.cppcompiler.option.optimize" value="de.innot.avreclipse.cppcompiler.optimize.two" valueType="enumerated"/>
 								<option id="de.innot.avreclipse.cppcompiler.option.otherflags.1506455547" name="Other flags" superClass="de.innot.avreclipse.cppcompiler.option.otherflags" value="-std=c++11" valueType="string"/>
 								<inputType id="de.innot.avreclipse.cppcompiler.input.1987206696" superClass="de.innot.avreclipse.cppcompiler.input"/>
 							</tool>
@@ -156,10 +156,10 @@
 		</scannerConfigBuildInfo>
 	</storageModule>
 	<storageModule moduleId="refreshScope" versionNumber="2">
-		<configuration configurationName="Release">
+		<configuration configurationName="Debug">
 			<resource resourceType="PROJECT" workspacePath="/MainBoard"/>
 		</configuration>
-		<configuration configurationName="Debug">
+		<configuration configurationName="Release">
 			<resource resourceType="PROJECT" workspacePath="/MainBoard"/>
 		</configuration>
 	</storageModule>

--- a/EclipseWS/MainBoard/Localcode/Board/Board.cpp
+++ b/EclipseWS/MainBoard/Localcode/Board/Board.cpp
@@ -50,9 +50,15 @@ namespace Board {
 		}
 
 		void vibrate(uint16_t duration) {
-			on();
-			if(duration > vibratorDuration) {
-				vibratorDuration = duration;
+			if(duration == 0) {
+				vibratorDuration = 0;
+				off();
+			}
+			else {
+				on();
+				if(duration > vibratorDuration) {
+					vibratorDuration = duration;
+				}
 			}
 		}
 
@@ -63,9 +69,9 @@ namespace Board {
 				default: break;
 				case 1:
 					if(vibratorDuration & 0b100000)
-						on();
-					else
 						off();
+					else
+						on();
 				}
 			}
 			else
@@ -132,6 +138,13 @@ namespace Board {
 				}
 			}
 		}
+	}
+
+	void reset() {
+		Vibrator::vibrate(0);
+
+		Buzzer::buzzerDuration = 0;
+		Buzzer::off();
 	}
 
 	void ISR1a() {

--- a/EclipseWS/MainBoard/Localcode/Board/Board.h
+++ b/EclipseWS/MainBoard/Localcode/Board/Board.h
@@ -61,6 +61,8 @@ namespace Board {
 		void sweep(uint16_t start, uint16_t end, uint16_t duration);
 	}
 
+	void reset();
+
 	void ISR1a();
 }
 

--- a/EclipseWS/MainBoard/Localcode/Board/VestBlink.h
+++ b/EclipseWS/MainBoard/Localcode/Board/VestBlink.h
@@ -22,7 +22,7 @@ extern uint8_t team;
 
 struct BlinkOverrides {
 	uint16_t duration;
-	uint16_t mode;
+	uint8_t mode;
 };
 
 extern BlinkOverrides overrides;

--- a/EclipseWS/MainBoard/Localcode/ESPComs/ESPUART.cpp
+++ b/EclipseWS/MainBoard/Localcode/ESPComs/ESPUART.cpp
@@ -12,6 +12,8 @@ namespace ESPComs {
 #define UDREI_ON 	UCSR0B |= (1<< UDRIE0)
 #define UDREI_OFF	UCSR0B &= ~(1<< UDRIE0)
 
+void (* resetCallback)() = 0;
+
 RXStates RXStatus = WAIT_FOR_START_RX;
 TXStates TXStatus = WAIT_FOR_START_TX;
 
@@ -41,6 +43,8 @@ ISR(USART_RX_vect) {
 		if(rData == START_CHAR) {
 			UDR0 = START_CHAR;
 			UDREI_ON;
+			if(resetCallback != 0)
+				resetCallback();
 			return;
 		}
 
@@ -94,6 +98,10 @@ void nextTXSource() {
 
 	UDREI_OFF;
 	TXStatus = TX_IDLE;
+}
+
+void onReset(void (* const newResetCallback)()) {
+	resetCallback = newResetCallback;
 }
 
 bool tryToStart(Source * txSource) {

--- a/EclipseWS/MainBoard/Localcode/ESPComs/ESPUART.cpp
+++ b/EclipseWS/MainBoard/Localcode/ESPComs/ESPUART.cpp
@@ -38,6 +38,12 @@ ISR(USART_RX_vect) {
 	break;
 
 	case RX_COMMAND:
+		if(rData == START_CHAR) {
+			UDR0 = START_CHAR;
+			UDREI_ON;
+			return;
+		}
+
 		RXEndpoint = Endpoint::getHeadEndpoint();
 		while(1) {
 			if(RXEndpoint == 0)

--- a/EclipseWS/MainBoard/Localcode/ESPComs/ESPUART.h
+++ b/EclipseWS/MainBoard/Localcode/ESPComs/ESPUART.h
@@ -31,6 +31,8 @@ enum TXStates {
 	TX_SENDING,
 };
 
+void onReset(void (* const resetCallback)());
+
 bool tryToStart(Source * txSource);
 void init();
 

--- a/EclipseWS/MainBoard/main.cpp
+++ b/EclipseWS/MainBoard/main.cpp
@@ -33,16 +33,16 @@ ESPComs::Endpoint VestBrightnessEP(200, &Board::Vest::mode, 1, 0);
 ESPComs::Endpoint BrightnessOverrideEp(12, &Board::Vest::overrides, 3, 0);
 
 struct BuzzCommand {
-	uint8_t length;
-	uint8_t startFreq;
-	uint8_t endFreq;
+	uint16_t length;
+	uint16_t startFreq;
+	uint16_t endFreq;
 };
 void playPing() {
 	BuzzCommand buzzCommand = *(BuzzCommand*)&ESPComs::Endpoint::pubBuffer;
 
-	Board::Buzzer::sweep(buzzCommand.startFreq*60, buzzCommand.endFreq*60, buzzCommand.length*10);
+	Board::Buzzer::sweep(buzzCommand.startFreq, buzzCommand.endFreq, buzzCommand.length);
 }
-ESPComs::Endpoint PingEndpoint(11, &ESPComs::Endpoint::pubBuffer, 3, playPing);
+ESPComs::Endpoint PingEndpoint(11, &ESPComs::Endpoint::pubBuffer, 6, playPing);
 
 void playVibration() {
 	Board::Vibrator::vibrate(*(uint16_t *)&ESPComs::Endpoint::pubBuffer);

--- a/EclipseWS/MainBoard/main.cpp
+++ b/EclipseWS/MainBoard/main.cpp
@@ -74,6 +74,7 @@ void IRRXCB(IR::ShotPacket data) {
 int main() {
 	_delay_ms(1500);
 	ESPComs::init();
+	ESPComs::onReset(Board::reset);
 
 	Board::Vest::mode = 3;
 	Board::Vest::team = 1;

--- a/EclipseWS/MainBoard/main.cpp
+++ b/EclipseWS/MainBoard/main.cpp
@@ -45,9 +45,9 @@ void playPing() {
 ESPComs::Endpoint PingEndpoint(11, &ESPComs::Endpoint::pubBuffer, 3, playPing);
 
 void playVibration() {
-	Board::Vibrator::vibrate(ESPComs::Endpoint::pubBuffer[0]*10);
+	Board::Vibrator::vibrate(*(uint16_t *)&ESPComs::Endpoint::pubBuffer);
 }
-ESPComs::Endpoint VibrationEP(10, &ESPComs::Endpoint::pubBuffer, 1, playVibration);
+ESPComs::Endpoint VibrationEP(10, &ESPComs::Endpoint::pubBuffer, 2, playVibration);
 
 uint8_t currentShotID = 1;
 void handleShots() {

--- a/Ruby/GameInterface/LTagPlayer.rb
+++ b/Ruby/GameInterface/LTagPlayer.rb
@@ -42,7 +42,7 @@ class Client
 
 	def team=(n)
 		n = n.to_i;
-		return false unless n != nil and n <= 7 and n >= 0;
+		raise ArgumentError, "Team out of range (must be between 0 and 255)" unless n != nil and n <= 255 and n >= 0;
 		@team = n;
 		@mqtt.publish_to "#{@mqttTopic}/Team", @team, retain: true;
 		return true;
@@ -56,7 +56,7 @@ class Client
 	end
 	def id=(n)
 		if(n != nil) then
-			raise ArgumentError, "ID must be a integer!" unless n.is_a? Integer;
+			raise ArgumentError, "ID must be integer or nil!" unless n.is_a? Integer;
 			raise ArgumentError, "ID out of range (0<ID<256)" unless n < 256 and n > 0;
 
 			@id = n;
@@ -131,7 +131,7 @@ class Client
 	private :console
 
 	def override_brightness(level, duration)
-		return false unless level.is_a? Integer and duration.is_a? Numeric
+		raise ArgumentError unless level.is_a? Integer and duration.is_a? Numeric
 		console("overrideVest(#{(duration*1000).to_i},#{level});");
 	end
 	def stop_brightness_override()
@@ -139,7 +139,7 @@ class Client
 	end
 
 	def vibrate(duration)
-		return false unless duration.is_a? Numeric and duration <= 2.55
+		raise ArgumentError, "Vibration-duration out of range (between 0 and 65.536)" unless duration.is_a? Numeric and duration <= 65.536 and duration >= 0
 		console("vibrate(#{(duration*1000).to_i});");
 	end
 


### PR DESCRIPTION
Since the current setup of solely using 8-bit values for sending times and frequencies has been a bit of a hindrance regarding the flexibility and stability of the system.
Vibrating for more than two seconds would already cause a problem, while at the same time, intervals were only selectable in 10ms intervals.

Now, the resolution is 1ms, while a maximum duration of more than a minute is supported. Plenty for any configuration :tada:

This should also close #12, which is nice :3 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xasworks/lzrtag/27)
<!-- Reviewable:end -->
