### PR TITLE
Brightness Keyword rework

### DIFF
--- a/Ruby/LasertagBase/lib/lzrtag/game/base_game.rb
+++ b/Ruby/LasertagBase/lib/lzrtag/game/base_game.rb
@@ -38,7 +38,7 @@ module LZRTag
 
 				@handler.each do |pl|
 					pl.noise(startF: 1000);
-					pl.brightness = 7;
+					pl.brightness = :active;
 				end
 			end
 

--- a/Ruby/LasertagBase/lib/lzrtag/handler/count_handler.rb
+++ b/Ruby/LasertagBase/lib/lzrtag/handler/count_handler.rb
@@ -1,10 +1,12 @@
 
 require_relative 'hitArb_handler.rb'
+require_relative '../player/hardware_player.rb'
 
 module LZRTag
 	module Handler
 		class Count < HitArb
 			attr_reader :teamCount
+			attr_reader :brightnessCount
 
 			def initialize(*args, **argHash)
 				super(*args, **argHash);
@@ -12,6 +14,11 @@ module LZRTag
 				@teamCount = Hash.new();
 				7.times do |i|
 					@teamCount[i] = 0;
+				end
+
+				@brightnessCount = Hash.new();
+				Player::Hardware.getBrightnessKeys().each do |bKey|
+					@brightnessCount[bKey] = 0;
 				end
 			end
 
@@ -21,11 +28,16 @@ module LZRTag
 				case evtName
 				when :playerConnected
 					@teamCount[data[0].team] += 1;
+					@brightnessCount[data[0].brightness] += 1;
 				when :playerDisconnected
 					@teamCount[data[0].team] -= 1;
+					@brightnessCount[data[0].brightness] -= 1;
 				when :playerTeamChanged
 					@teamCount[data[1]] -= 1;
 					@teamCount[data[0].team] += 1;
+				when :playerBrightnessChanged
+					@brightnessCount[data[1]] -= 1;
+					@brightnessCount[data[0].brightness] += 1;
 				end
 			end
 		end

--- a/Ruby/LasertagBase/lib/lzrtag/handler/count_handler.rb
+++ b/Ruby/LasertagBase/lib/lzrtag/handler/count_handler.rb
@@ -26,10 +26,10 @@ module LZRTag
 				super(evtName, data);
 
 				case evtName
-				when :playerConnected
+				when :playerRegistered
 					@teamCount[data[0].team] += 1;
 					@brightnessCount[data[0].brightness] += 1;
-				when :playerDisconnected
+				when :playerUnregistered
 					@teamCount[data[0].team] -= 1;
 					@brightnessCount[data[0].brightness] -= 1;
 				when :playerTeamChanged

--- a/Ruby/LasertagBase/lib/lzrtag/hooks/standard_hooks.rb
+++ b/Ruby/LasertagBase/lib/lzrtag/hooks/standard_hooks.rb
@@ -66,11 +66,13 @@ module LZRTag
 				@possibleTeams = possibleTeams;
 			end
 
-			on :playerConnected do |pl|
-				pl.brightness = 1;
+			on :playerRegistered do |pl|
+				pl.brightness = :teamSelect;
 			end
 
 			on :navSwitchPressed do |player, dir|
+				next if player.brightness == :active
+
 				newTeam = @possibleTeams.find_index(player.team) || 0;
 
 				newTeam += 1 if(dir == 2)
@@ -78,7 +80,7 @@ module LZRTag
 
 				player.team = @possibleTeams[newTeam % @possibleTeams.length]
 
-				player.brightness = 3 if(dir == 1)
+				player.brightness = :active if(dir == 1)
 			end
 		end
 

--- a/Ruby/LasertagBase/lib/lzrtag/player/hardware_player.rb
+++ b/Ruby/LasertagBase/lib/lzrtag/player/hardware_player.rb
@@ -40,6 +40,8 @@ module LZRTag
 
 				@battery = 0; @ping = 0; @heap = 0;
 
+				@BrightnessMap = [:idle, :teamSelect, :dead, :active];
+
 				# These values are configured for a DPS ~1, equal to all weapons
 				# Including reload timings and other penalties
 				@GunDamageMultipliers = [
@@ -114,8 +116,9 @@ module LZRTag
 				@team;
 			end
 			def brightness=(n)
-				n = n.to_i;
-				raise ArgumentError, "Brightness out of range (must be between 0 and 7)" unless n <= 7 and n >= 0;
+				raise ArgumentError, "Brightness must be nil or a valid symbol!" unless n.nil or @BrightnessMap.include? n;
+				n = @BrightnessMap.find_index(n) if n.is_a? Symbol
+
 				return if @brightness == n;
 
 				@brightness = n;

--- a/Ruby/LasertagBase/lib/lzrtag/player/hardware_player.rb
+++ b/Ruby/LasertagBase/lib/lzrtag/player/hardware_player.rb
@@ -124,7 +124,7 @@ module LZRTag
 				raise ArgumentError, "Brightness must be a valid symbol!" unless @BrightnessMap.include? n;
 
 				return if @brightness == n;
-				oldB = n;
+				oldB = @brightness;
 				@brightness = n;
 
 				n = @BrightnessMap.find_index(n)

--- a/Ruby/LasertagBase/lib/lzrtag/player/hardware_player.rb
+++ b/Ruby/LasertagBase/lib/lzrtag/player/hardware_player.rb
@@ -20,13 +20,17 @@ module LZRTag
 
 			attr_reader :battery, :ping, :heap
 
-			attr_reader :fireConfig, :hitConfig
+			attr_reader :fireConfig, :hitConfig;
+
+			def self.getBrightnessKeys()
+				return [:idle, :teamSelect, :dead, :active]
+			end
 
 			def initialize(*data)
 				super(*data);
 
 				@team = 0;
-				@brightness = 0;
+				@brightness = :idle;
 
 				@dead = false;
 				@deathChangeTime = Time.now();
@@ -40,7 +44,7 @@ module LZRTag
 
 				@battery = 0; @ping = 0; @heap = 0;
 
-				@BrightnessMap = [:idle, :teamSelect, :dead, :active];
+				@BrightnessMap = self.class.getBrightnessKeys();
 
 				# These values are configured for a DPS ~1, equal to all weapons
 				# Including reload timings and other penalties
@@ -113,16 +117,20 @@ module LZRTag
 
 				_pub_to "Team", @team, retain: true;
 				@handler.send_event :playerTeamChanged, self, oldT;
+
 				@team;
 			end
 			def brightness=(n)
-				raise ArgumentError, "Brightness must be nil or a valid symbol!" unless n.nil or @BrightnessMap.include? n;
-				n = @BrightnessMap.find_index(n) if n.is_a? Symbol
+				raise ArgumentError, "Brightness must be a valid symbol!" unless @BrightnessMap.include? n;
 
 				return if @brightness == n;
-
+				oldB = n;
 				@brightness = n;
-				_pub_to "FX/Brightness", @brightness, retain: true;
+
+				n = @BrightnessMap.find_index(n)
+
+				_pub_to "FX/Brightness", n, retain: true;
+				@handler.send_event :playerBrightnessChanged, self, oldB;
 
 				@brightness;
 			end


### PR DESCRIPTION
A PR to double-check for Issue #59 
Ruby test script has been working fine, and the new symbols will make maintaining consistent behaviour a LOT easier, even as more brightness modes get added.
Hooray for that!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xasworks/lzrtag/64)
<!-- Reviewable:end -->
